### PR TITLE
docs: fix simple typo, varation -> variation

### DIFF
--- a/hashes/geohash.py
+++ b/hashes/geohash.py
@@ -21,7 +21,7 @@ from .hashtype import hashtype
 
 
 class geohash(hashtype):
-    # Not the actual RFC 4648 standard; a varation
+    # Not the actual RFC 4648 standard; a variation
     _base32 = '0123456789bcdefghjkmnpqrstuvwxyz'
     _base32_map = {}
     for i in range(len(_base32)):


### PR DESCRIPTION
There is a small typo in hashes/geohash.py.

Should read `variation` rather than `varation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md